### PR TITLE
Use _group_shipment_key for return too

### DIFF
--- a/sale.py
+++ b/sale.py
@@ -385,6 +385,8 @@ class Sale:
         rv = super(Sale, self)._group_shipment_key(moves, move)
         return rv + (('delivery_mode', line.delivery_mode),)
 
+    _group_return_key = _group_shipment_key
+
     def create_shipment(self, shipment_type):
         """
         This method creates the shipments for the given sale order.
@@ -463,7 +465,7 @@ class Sale:
         if not invoice:
             return invoice
 
-        if self.invoice_method == 'shipment' and invoice_type == 'out_invoice':
+        if self.invoice_method == 'shipment':
             # Invoices created from shipment can be automatically opened
             # for payment.
             Invoice.post([invoice])

--- a/tests/test_sale.py
+++ b/tests/test_sale.py
@@ -1049,10 +1049,19 @@ class TestSale(unittest.TestCase):
                 'invoice_method': 'shipment',
                 'shipment_method': 'order',
             }])
-            sale_line, = self.SaleLine.create([{
+            self.SaleLine.create([{
                 'sale': sale,
                 'type': 'line',
                 'quantity': 2,
+                'delivery_mode': 'ship',
+                'unit': self.uom,
+                'unit_price': 20000,
+                'description': 'Test description',
+                'product': self.product1.id
+            }, {
+                'sale': sale,
+                'type': 'line',
+                'quantity': -2,
                 'delivery_mode': 'ship',
                 'unit': self.uom,
                 'unit_price': 20000,
@@ -1068,6 +1077,12 @@ class TestSale(unittest.TestCase):
             self.assertEqual(len(sale.shipments), 1)
             self.assertEqual(sale.shipments[0].delivery_mode, 'ship')
             self.assertEqual(sale.shipments[0].state, 'waiting')
+
+            self.assertEqual(len(sale.shipment_returns), 1)
+            self.assertEqual(sale.shipment_returns[0].delivery_mode, 'ship')
+            # On processing return sale, the shipment is in draft.
+            # It's weird, but that is how tryton does it
+            self.assertEqual(sale.shipment_returns[0].state, 'draft')
 
             self.assertEqual(len(sale.invoices), 0)
 
@@ -1095,10 +1110,19 @@ class TestSale(unittest.TestCase):
                 'invoice_method': 'shipment',
                 'shipment_method': 'order',
             }])
-            sale_line, = self.SaleLine.create([{
+            self.SaleLine.create([{
                 'sale': sale,
                 'type': 'line',
                 'quantity': 2,
+                'delivery_mode': 'pick_up',
+                'unit': self.uom,
+                'unit_price': 20000,
+                'description': 'Test description',
+                'product': self.product1.id
+            }, {
+                'sale': sale,
+                'type': 'line',
+                'quantity': -2,
                 'delivery_mode': 'pick_up',
                 'unit': self.uom,
                 'unit_price': 20000,
@@ -1116,8 +1140,13 @@ class TestSale(unittest.TestCase):
                 self.assertEqual(sale.shipments[0].delivery_mode, 'pick_up')
                 self.assertEqual(sale.shipments[0].state, 'done')
 
-                self.assertEqual(len(sale.invoices), 1)
+                self.assertEqual(len(sale.shipment_returns), 1)
+                self.assertEqual(sale.shipment_returns[0].delivery_mode, 'pick_up')
+                self.assertEqual(sale.shipment_returns[0].state, 'done')
+
+                self.assertEqual(len(sale.invoices), 2)
                 self.assertEqual(sale.invoices[0].state, 'posted')
+                self.assertEqual(sale.invoices[1].state, 'posted')
 
     def test_1130_delivery_method_2shipping_case_3(self):
         """


### PR DESCRIPTION
* The return_key in the core module refers to the _group_shipment_key
  method object. Implement the same here

Before this patch the delivery_mode was not set correctly on the
return shipment and there were no tests testing it. Fixing this also
revealed another bug where the credit notes were not automatically
posted like invoices from picked sales. This patch fixes that too and
tests them